### PR TITLE
improve formatting of description lists and \seealso section

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,5 +18,5 @@ Imports:
 License: GPL-2 | file LICENSE
 URL: https://github.com/datastorm-open/suncalc
 NeedsCompilation: no
-RoxygenNote: 7.2.1
 Encoding: UTF-8
+Config/roxygen2/version: 8.0.0

--- a/R/getMoonIllumination.R
+++ b/R/getMoonIllumination.R
@@ -1,32 +1,33 @@
 #' Get Moon illumination
 #' 
-#' @param date : Single or multiple DateTime. Can be a \code{Date} (YYYY-MM-DD), 
+#' @param date Single or multiple DateTime. Can be a \code{Date} (YYYY-MM-DD),
 #' a \code{character} in UTC (YYYY-MM-DD HH:mm:ss) or a \code{POSIXct}
-#' @param keep : \code{character}. Vector of variables to keep. See \code{Details}
+#' @param keep \code{character}. Vector of variables to keep. See \code{Details}
 #' 
 #' @return \code{data.frame}
 #' 
 #' @details 
 #' 
-#' Returns an object with the following properties:
+#' Computes the following properties:
 #' 
-#' \itemize{
-#'   \item{"fraction"}{ :  illuminated fraction of the moon; varies from 0.0 (new moon) to 1.0 (full moon)}
-#'   \item{"phase"}{ :  moon phase; varies from 0.0 to 1.0, described below}
-#'   \item{"angle"}{ :  midpoint angle in radians of the illuminated limb of the moon reckoned eastward from 
+#' \describe{
+#'   \item{"fraction"}{illuminated fraction of the moon; varies from 0.0 (new moon) to 1.0 (full moon)}
+#'   \item{"phase"}{moon phase; varies from 0.0 to 1.0, described below}
+#'   \item{"angle"}{midpoint angle in radians of the illuminated limb of the moon reckoned eastward from 
 #' the north point of the disk; the moon is waxing if the angle is negative, and waning if positive}
 #' }
 #' 
 #' Moon phase value should be interpreted like this:
-#' \itemize{
-#'   \item{0}{ : New Moon}
-#'   \item{}{Waxing Crescent}
-#'   \item{0.25}{ : First Quarter}
-#'   \item{}{ : Waxing Gibbous}
-#'   \item{0.5}{Full Moon}
-#'   \item{}{ : Waning Gibbous}
-#'   \item{0.75}{Last Quarter}
-#'   \item{}{ : Waning Crescent}
+#' \tabular{ll}{
+#'   0    \tab New Moon\cr
+#'        \tab Waxing Crescent\cr
+#'   0.25 \tab First Quarter\cr
+#'        \tab Waxing Gibbous\cr
+#'   0.5  \tab Full Moon\cr
+#'        \tab Waning Gibbous\cr
+#'   0.75 \tab Last Quarter\cr
+#'        \tab Waning Crescent\cr
+#'   1    \tab New Moon
 #'} 
 #'
 #' By subtracting the parallacticAngle from the angle one can get the zenith angle of the moons bright limb (anticlockwise). The zenith angle can be used do draw the moon shape from the observers perspective (e.g. moon lying on its back).
@@ -58,8 +59,7 @@
 #' 
 #' @export
 #' 
-#' @seealso \link{getSunlightTimes}, \link{getMoonTimes}, \link{getMoonIllumination},
-#' \link{getMoonPosition},\link{getSunlightPosition}
+#' @family suncalc functions
 #' 
 getMoonIllumination <- function(date = Sys.Date(),
                          keep = c("fraction", "phase", "angle")){

--- a/R/getMoonPosition.R
+++ b/R/getMoonPosition.R
@@ -1,11 +1,11 @@
 #' Get Moon position
 #' 
-#' @param date : Single or multiple DateTime. Can be a \code{Date} (YYYY-MM-DD), 
+#' @param date Single or multiple DateTime. Can be a \code{Date} (YYYY-MM-DD),
 #' a \code{character} in UTC (YYYY-MM-DD HH:mm:ss) or a \code{POSIXct}
-#' @param lat : \code{numeric}. Single latitude
-#' @param lon : \code{numeric}. Single longitude
-#' @param data : \code{data.frame}. Alternative to use \code{date}, \code{lat}, \code{lon} for passing multiple coordinates
-#' @param keep : \code{character}. Vector of variables to keep. See \code{Details}
+#' @param lat \code{numeric}. Single latitude
+#' @param lon \code{numeric}. Single longitude
+#' @param data \code{data.frame}. Alternative to use \code{date}, \code{lat}, \code{lon} for passing multiple coordinates
+#' @param keep \code{character}. Vector of variables to keep. See \code{Details}
 #' 
 #' @return \code{data.frame}
 #' 
@@ -13,11 +13,11 @@
 #' 
 #' Returns an object with the following properties:
 #' 
-#' \itemize{
-#'   \item{"altitude"}{ : moon altitude above the horizon in radians}
-#'   \item{"azimuth"}{ : moon azimuth in radians}
-#'   \item{"distance"}{ : distance to moon in kilometers}
-#'   \item{"parallacticAngle"}{ : parallactic angle of the moon in radians}
+#' \describe{
+#'   \item{"altitude"}{moon altitude above the horizon in radians}
+#'   \item{"azimuth"}{moon azimuth in radians}
+#'   \item{"distance"}{distance to moon in kilometers}
+#'   \item{"parallacticAngle"}{parallactic angle of the moon in radians}
 #' }
 #' 
 #' @examples 
@@ -58,8 +58,7 @@
 #' 
 #' @export
 #' 
-#' @seealso \link{getSunlightTimes}, \link{getMoonTimes}, \link{getMoonIllumination},
-#' \link{getMoonPosition},\link{getSunlightPosition}
+#' @family suncalc functions
 #' 
 getMoonPosition <- function(date = NULL, lat = NULL, lon = NULL, data = NULL,
                             keep = c("altitude", "azimuth", "distance", "parallacticAngle")){

--- a/R/getMoonTimes.R
+++ b/R/getMoonTimes.R
@@ -1,12 +1,12 @@
 #' Get Moon times
 #' 
-#' @param date : \code{Date}. Single or multiple Date. YYYY-MM-DD
-#' @param lat : \code{numeric}. Single latitude
-#' @param lon : \code{numeric}. Single longitude
-#' @param data : \code{data.frame}. Alternative to use \code{date}, \code{lat}, \code{lon} for passing multiple coordinates
-#' @param keep : \code{character}. Vector of variables to keep. See \code{Details}
-#' @param tz : \code{character}. Timezone of results
-#' @param ... :Not used. (Maintenance only)
+#' @param date \code{Date}. Single or multiple Date. YYYY-MM-DD
+#' @param lat \code{numeric}. Single latitude
+#' @param lon \code{numeric}. Single longitude
+#' @param data \code{data.frame}. Alternative to use \code{date}, \code{lat}, \code{lon} for passing multiple coordinates
+#' @param keep \code{character}. Vector of variables to keep. See \code{Details}
+#' @param tz \code{character}. Timezone of results
+#' @param ... Not used. (Maintenance only)
 #' 
 #' @return \code{data.frame}
 #' 
@@ -14,11 +14,11 @@
 #' 
 #' Available variables are :
 #' 
-#' \itemize{
-#'   \item{"rise"}{ : \code{Date}. moonrise time}
-#'   \item{"set"}{ : \code{Date}. moonset time}
-#'   \item{"alwaysUp"}{ : \code{Logical}. TRUE if the moon never rises or sets and is always above the horizon during the day}
-#'   \item{"alwaysDown"}{ : \code{Logical}. TRUE if the moon is always below the horizon}
+#' \describe{
+#'   \item{"rise"}{\code{Date}. moonrise time}
+#'   \item{"set"}{\code{Date}. moonset time}
+#'   \item{"alwaysUp"}{\code{Logical}. TRUE if the moon never rises or sets and is always above the horizon during the day}
+#'   \item{"alwaysDown"}{\code{Logical}. TRUE if the moon is always below the horizon}
 #' }
 #' 
 #' @examples 
@@ -47,8 +47,7 @@
 #' 
 #' @export
 #' 
-#' @seealso \link{getSunlightTimes}, \link{getMoonTimes}, \link{getMoonIllumination},
-#' \link{getMoonPosition},\link{getSunlightPosition}
+#' @family suncalc functions
 #' 
 getMoonTimes <- function(date = NULL, lat = NULL, lon = NULL, data = NULL,
                              keep = c("rise", "set", "alwaysUp", "alwaysDown"), 

--- a/R/getSunlightPosition.R
+++ b/R/getSunlightPosition.R
@@ -1,11 +1,11 @@
 #' Get Sunlight position
 #' 
-#' @param date : Single or multiple DateTime. Can be a \code{Date} (YYYY-MM-DD), 
+#' @param date Single or multiple DateTime. Can be a \code{Date} (YYYY-MM-DD),
 #' a \code{character} in UTC (YYYY-MM-DD HH:mm:ss) or a \code{POSIXct}
-#' @param lat : \code{numeric}. Single latitude
-#' @param lon : \code{numeric}. Single longitude
-#' @param data : \code{data.frame}. Alternative to use \code{date}, \code{lat}, \code{lon} for passing multiple coordinates
-#' @param keep : \code{character}. Vector of variables to keep. See \code{Details}
+#' @param lat \code{numeric}. Single latitude
+#' @param lon \code{numeric}. Single longitude
+#' @param data \code{data.frame}. Alternative to use \code{date}, \code{lat}, \code{lon} for passing multiple coordinates
+#' @param keep \code{character}. Vector of variables to keep. See \code{Details}
 #' 
 #' @return \code{data.frame}
 #' 
@@ -13,9 +13,9 @@
 #' 
 #' Returns an object with the following properties:
 #' 
-#' \itemize{
-#'   \item{"altitude"}{ : sun altitude above the horizon in radians, e.g. 0 at the horizon and PI/2 at the zenith (straight over your head)}
-#'   \item{"azimuth"}{ : sun azimuth in radians (direction along the horizon, measured from south to west), e.g. 0 is south and Math.PI * 3/4 is northwest}
+#' \describe{
+#'   \item{"altitude"}{sun altitude above the horizon in radians, e.g. 0 at the horizon and PI/2 at the zenith (straight over your head)}
+#'   \item{"azimuth"}{sun azimuth in radians (direction along the horizon, measured from south to west), e.g. 0 is south and Math.PI * 3/4 is northwest}
 #' }
 #' 
 #' @examples 
@@ -56,8 +56,7 @@
 #' 
 #' @export
 #' 
-#' @seealso \link{getSunlightTimes}, \link{getMoonTimes}, \link{getMoonIllumination},
-#' \link{getMoonPosition},\link{getSunlightPosition}
+#' @family suncalc functions
 #' 
 getSunlightPosition <- function(date = NULL, lat = NULL, lon = NULL, data = NULL,
                             keep = c("altitude", "azimuth")) {

--- a/R/getSunlightTimes.R
+++ b/R/getSunlightTimes.R
@@ -1,11 +1,11 @@
 #' Get Sunlight times
 #' 
-#' @param date : \code{Date}. Single or multiple Date. YYYY-MM-DD
-#' @param lat : \code{numeric}. Single latitude
-#' @param lon : \code{numeric}. Single longitude
-#' @param data : \code{data.frame}. Alternative to use \code{date}, \code{lat}, \code{lon} for passing multiple coordinates
-#' @param keep : \code{character}. Vector of variables to keep. See \code{Details}
-#' @param tz : \code{character}. Timezone of results
+#' @param date \code{Date}. Single or multiple Date. YYYY-MM-DD
+#' @param lat \code{numeric}. Single latitude
+#' @param lon \code{numeric}. Single longitude
+#' @param data \code{data.frame}. Alternative to use \code{date}, \code{lat}, \code{lon} for passing multiple coordinates
+#' @param keep \code{character}. Vector of variables to keep. See \code{Details}
+#' @param tz \code{character}. Timezone of results
 #' 
 #' @return \code{data.frame}
 #' 
@@ -13,21 +13,21 @@
 #' 
 #' Available variables are :
 #' 
-#' \itemize{
-#'   \item{"sunrise"}{ : sunrise (top edge of the sun appears on the horizon)}
-#'   \item{"sunriseEnd"}{ : sunrise ends (bottom edge of the sun touches the horizon)}
-#'   \item{"goldenHourEnd"}{ : morning golden hour (soft light, best time for photography) ends}
-#'   \item{"solarNoon"}{ : solar noon (sun is in the highest position)}
-#'   \item{"goldenHour"}{ : evening golden hour starts}
-#'   \item{"sunsetStart"}{ : sunset starts (bottom edge of the sun touches the horizon)}
-#'   \item{"sunset"}{ : sunset (sun disappears below the horizon, evening civil twilight starts)}
-#'   \item{"dusk"}{ : dusk (evening nautical twilight starts)}
-#'   \item{"nauticalDusk"}{ : nautical dusk (evening astronomical twilight starts)}
-#'   \item{"night"}{ : night starts (dark enough for astronomical observations)}
-#'   \item{"nadir"}{ : nadir (darkest moment of the night, sun is in the lowest position)}
-#'   \item{"nightEnd"}{ : night ends (morning astronomical twilight starts)}
-#'   \item{"nauticalDawn"}{ : nautical dawn (morning nautical twilight starts)}
-#'   \item{"dawn"}{ : dawn (morning nautical twilight ends, morning civil twilight starts)}
+#' \describe{
+#'   \item{"sunrise"}{sunrise (top edge of the sun appears on the horizon)}
+#'   \item{"sunriseEnd"}{sunrise ends (bottom edge of the sun touches the horizon)}
+#'   \item{"goldenHourEnd"}{morning golden hour (soft light, best time for photography) ends}
+#'   \item{"solarNoon"}{solar noon (sun is in the highest position)}
+#'   \item{"goldenHour"}{evening golden hour starts}
+#'   \item{"sunsetStart"}{sunset starts (bottom edge of the sun touches the horizon)}
+#'   \item{"sunset"}{sunset (sun disappears below the horizon, evening civil twilight starts)}
+#'   \item{"dusk"}{dusk (evening nautical twilight starts)}
+#'   \item{"nauticalDusk"}{nautical dusk (evening astronomical twilight starts)}
+#'   \item{"night"}{night starts (dark enough for astronomical observations)}
+#'   \item{"nadir"}{nadir (darkest moment of the night, sun is in the lowest position)}
+#'   \item{"nightEnd"}{night ends (morning astronomical twilight starts)}
+#'   \item{"nauticalDawn"}{nautical dawn (morning nautical twilight starts)}
+#'   \item{"dawn"}{dawn (morning nautical twilight ends, morning civil twilight starts)}
 #' }
 #' 
 #' @examples 
@@ -57,8 +57,7 @@
 #' 
 #' @export
 #' 
-#' @seealso \link{getSunlightTimes}, \link{getMoonTimes}, \link{getMoonIllumination},
-#' \link{getMoonPosition},\link{getSunlightPosition}
+#' @family suncalc functions
 #' 
 getSunlightTimes <- function(date = NULL, lat = NULL, lon = NULL, data = NULL,
                              keep = c("solarNoon", "nadir", "sunrise", "sunset", "sunriseEnd", "sunsetStart",  

--- a/man/getMoonIllumination.Rd
+++ b/man/getMoonIllumination.Rd
@@ -7,10 +7,10 @@
 getMoonIllumination(date = Sys.Date(), keep = c("fraction", "phase", "angle"))
 }
 \arguments{
-\item{date}{: Single or multiple DateTime. Can be a \code{Date} (YYYY-MM-DD), 
+\item{date}{Single or multiple DateTime. Can be a \code{Date} (YYYY-MM-DD),
 a \code{character} in UTC (YYYY-MM-DD HH:mm:ss) or a \code{POSIXct}}
 
-\item{keep}{: \code{character}. Vector of variables to keep. See \code{Details}}
+\item{keep}{\code{character}. Vector of variables to keep. See \code{Details}}
 }
 \value{
 \code{data.frame}
@@ -19,25 +19,26 @@ a \code{character} in UTC (YYYY-MM-DD HH:mm:ss) or a \code{POSIXct}}
 Get Moon illumination
 }
 \details{
-Returns an object with the following properties:
+Computes the following properties:
 
-\itemize{
-  \item{"fraction"}{ :  illuminated fraction of the moon; varies from 0.0 (new moon) to 1.0 (full moon)}
-  \item{"phase"}{ :  moon phase; varies from 0.0 to 1.0, described below}
-  \item{"angle"}{ :  midpoint angle in radians of the illuminated limb of the moon reckoned eastward from 
+\describe{
+  \item{"fraction"}{illuminated fraction of the moon; varies from 0.0 (new moon) to 1.0 (full moon)}
+  \item{"phase"}{moon phase; varies from 0.0 to 1.0, described below}
+  \item{"angle"}{midpoint angle in radians of the illuminated limb of the moon reckoned eastward from 
 the north point of the disk; the moon is waxing if the angle is negative, and waning if positive}
 }
 
 Moon phase value should be interpreted like this:
-\itemize{
-  \item{0}{ : New Moon}
-  \item{}{Waxing Crescent}
-  \item{0.25}{ : First Quarter}
-  \item{}{ : Waxing Gibbous}
-  \item{0.5}{Full Moon}
-  \item{}{ : Waning Gibbous}
-  \item{0.75}{Last Quarter}
-  \item{}{ : Waning Crescent}
+\tabular{ll}{
+  0    \tab New Moon\cr
+       \tab Waxing Crescent\cr
+  0.25 \tab First Quarter\cr
+       \tab Waxing Gibbous\cr
+  0.5  \tab Full Moon\cr
+       \tab Waning Gibbous\cr
+  0.75 \tab Last Quarter\cr
+       \tab Waning Crescent\cr
+  1    \tab New Moon
 } 
 
 By subtracting the parallacticAngle from the angle one can get the zenith angle of the moons bright limb (anticlockwise). The zenith angle can be used do draw the moon shape from the observers perspective (e.g. moon lying on its back).
@@ -62,6 +63,10 @@ res <- getMoonIllumination(date = date_cet)
       
 }
 \seealso{
-\link{getSunlightTimes}, \link{getMoonTimes}, \link{getMoonIllumination},
-\link{getMoonPosition},\link{getSunlightPosition}
+Other suncalc functions:
+\code{\link[=getMoonPosition]{getMoonPosition()}},
+\code{\link[=getMoonTimes]{getMoonTimes()}},
+\code{\link[=getSunlightPosition]{getSunlightPosition()}},
+\code{\link[=getSunlightTimes]{getSunlightTimes()}}
 }
+\concept{suncalc functions}

--- a/man/getMoonPosition.Rd
+++ b/man/getMoonPosition.Rd
@@ -13,16 +13,16 @@ getMoonPosition(
 )
 }
 \arguments{
-\item{date}{: Single or multiple DateTime. Can be a \code{Date} (YYYY-MM-DD), 
+\item{date}{Single or multiple DateTime. Can be a \code{Date} (YYYY-MM-DD),
 a \code{character} in UTC (YYYY-MM-DD HH:mm:ss) or a \code{POSIXct}}
 
-\item{lat}{: \code{numeric}. Single latitude}
+\item{lat}{\code{numeric}. Single latitude}
 
-\item{lon}{: \code{numeric}. Single longitude}
+\item{lon}{\code{numeric}. Single longitude}
 
-\item{data}{: \code{data.frame}. Alternative to use \code{date}, \code{lat}, \code{lon} for passing multiple coordinates}
+\item{data}{\code{data.frame}. Alternative to use \code{date}, \code{lat}, \code{lon} for passing multiple coordinates}
 
-\item{keep}{: \code{character}. Vector of variables to keep. See \code{Details}}
+\item{keep}{\code{character}. Vector of variables to keep. See \code{Details}}
 }
 \value{
 \code{data.frame}
@@ -33,11 +33,11 @@ Get Moon position
 \details{
 Returns an object with the following properties:
 
-\itemize{
-  \item{"altitude"}{ : moon altitude above the horizon in radians}
-  \item{"azimuth"}{ : moon azimuth in radians}
-  \item{"distance"}{ : distance to moon in kilometers}
-  \item{"parallacticAngle"}{ : parallactic angle of the moon in radians}
+\describe{
+  \item{"altitude"}{moon altitude above the horizon in radians}
+  \item{"azimuth"}{moon azimuth in radians}
+  \item{"distance"}{distance to moon in kilometers}
+  \item{"parallacticAngle"}{parallactic angle of the moon in radians}
 }
 }
 \examples{
@@ -71,6 +71,10 @@ getMoonPosition(data = data,
       
 }
 \seealso{
-\link{getSunlightTimes}, \link{getMoonTimes}, \link{getMoonIllumination},
-\link{getMoonPosition},\link{getSunlightPosition}
+Other suncalc functions:
+\code{\link[=getMoonIllumination]{getMoonIllumination()}},
+\code{\link[=getMoonTimes]{getMoonTimes()}},
+\code{\link[=getSunlightPosition]{getSunlightPosition()}},
+\code{\link[=getSunlightTimes]{getSunlightTimes()}}
 }
+\concept{suncalc functions}

--- a/man/getMoonTimes.Rd
+++ b/man/getMoonTimes.Rd
@@ -15,19 +15,19 @@ getMoonTimes(
 )
 }
 \arguments{
-\item{date}{: \code{Date}. Single or multiple Date. YYYY-MM-DD}
+\item{date}{\code{Date}. Single or multiple Date. YYYY-MM-DD}
 
-\item{lat}{: \code{numeric}. Single latitude}
+\item{lat}{\code{numeric}. Single latitude}
 
-\item{lon}{: \code{numeric}. Single longitude}
+\item{lon}{\code{numeric}. Single longitude}
 
-\item{data}{: \code{data.frame}. Alternative to use \code{date}, \code{lat}, \code{lon} for passing multiple coordinates}
+\item{data}{\code{data.frame}. Alternative to use \code{date}, \code{lat}, \code{lon} for passing multiple coordinates}
 
-\item{keep}{: \code{character}. Vector of variables to keep. See \code{Details}}
+\item{keep}{\code{character}. Vector of variables to keep. See \code{Details}}
 
-\item{tz}{: \code{character}. Timezone of results}
+\item{tz}{\code{character}. Timezone of results}
 
-\item{...}{:Not used. (Maintenance only)}
+\item{...}{Not used. (Maintenance only)}
 }
 \value{
 \code{data.frame}
@@ -38,11 +38,11 @@ Get Moon times
 \details{
 Available variables are :
 
-\itemize{
-  \item{"rise"}{ : \code{Date}. moonrise time}
-  \item{"set"}{ : \code{Date}. moonset time}
-  \item{"alwaysUp"}{ : \code{Logical}. TRUE if the moon never rises or sets and is always above the horizon during the day}
-  \item{"alwaysDown"}{ : \code{Logical}. TRUE if the moon is always below the horizon}
+\describe{
+  \item{"rise"}{\code{Date}. moonrise time}
+  \item{"set"}{\code{Date}. moonset time}
+  \item{"alwaysUp"}{\code{Logical}. TRUE if the moon never rises or sets and is always above the horizon during the day}
+  \item{"alwaysDown"}{\code{Logical}. TRUE if the moon is always below the horizon}
 }
 }
 \examples{
@@ -64,6 +64,10 @@ getMoonTimes(data = data, tz = "CET")
       
 }
 \seealso{
-\link{getSunlightTimes}, \link{getMoonTimes}, \link{getMoonIllumination},
-\link{getMoonPosition},\link{getSunlightPosition}
+Other suncalc functions:
+\code{\link[=getMoonIllumination]{getMoonIllumination()}},
+\code{\link[=getMoonPosition]{getMoonPosition()}},
+\code{\link[=getSunlightPosition]{getSunlightPosition()}},
+\code{\link[=getSunlightTimes]{getSunlightTimes()}}
 }
+\concept{suncalc functions}

--- a/man/getSunlightPosition.Rd
+++ b/man/getSunlightPosition.Rd
@@ -13,16 +13,16 @@ getSunlightPosition(
 )
 }
 \arguments{
-\item{date}{: Single or multiple DateTime. Can be a \code{Date} (YYYY-MM-DD), 
+\item{date}{Single or multiple DateTime. Can be a \code{Date} (YYYY-MM-DD),
 a \code{character} in UTC (YYYY-MM-DD HH:mm:ss) or a \code{POSIXct}}
 
-\item{lat}{: \code{numeric}. Single latitude}
+\item{lat}{\code{numeric}. Single latitude}
 
-\item{lon}{: \code{numeric}. Single longitude}
+\item{lon}{\code{numeric}. Single longitude}
 
-\item{data}{: \code{data.frame}. Alternative to use \code{date}, \code{lat}, \code{lon} for passing multiple coordinates}
+\item{data}{\code{data.frame}. Alternative to use \code{date}, \code{lat}, \code{lon} for passing multiple coordinates}
 
-\item{keep}{: \code{character}. Vector of variables to keep. See \code{Details}}
+\item{keep}{\code{character}. Vector of variables to keep. See \code{Details}}
 }
 \value{
 \code{data.frame}
@@ -33,9 +33,9 @@ Get Sunlight position
 \details{
 Returns an object with the following properties:
 
-\itemize{
-  \item{"altitude"}{ : sun altitude above the horizon in radians, e.g. 0 at the horizon and PI/2 at the zenith (straight over your head)}
-  \item{"azimuth"}{ : sun azimuth in radians (direction along the horizon, measured from south to west), e.g. 0 is south and Math.PI * 3/4 is northwest}
+\describe{
+  \item{"altitude"}{sun altitude above the horizon in radians, e.g. 0 at the horizon and PI/2 at the zenith (straight over your head)}
+  \item{"azimuth"}{sun azimuth in radians (direction along the horizon, measured from south to west), e.g. 0 is south and Math.PI * 3/4 is northwest}
 }
 }
 \examples{
@@ -69,6 +69,10 @@ getSunlightPosition(data = data,
       
 }
 \seealso{
-\link{getSunlightTimes}, \link{getMoonTimes}, \link{getMoonIllumination},
-\link{getMoonPosition},\link{getSunlightPosition}
+Other suncalc functions:
+\code{\link[=getMoonIllumination]{getMoonIllumination()}},
+\code{\link[=getMoonPosition]{getMoonPosition()}},
+\code{\link[=getMoonTimes]{getMoonTimes()}},
+\code{\link[=getSunlightTimes]{getSunlightTimes()}}
 }
+\concept{suncalc functions}

--- a/man/getSunlightTimes.Rd
+++ b/man/getSunlightTimes.Rd
@@ -16,17 +16,17 @@ getSunlightTimes(
 )
 }
 \arguments{
-\item{date}{: \code{Date}. Single or multiple Date. YYYY-MM-DD}
+\item{date}{\code{Date}. Single or multiple Date. YYYY-MM-DD}
 
-\item{lat}{: \code{numeric}. Single latitude}
+\item{lat}{\code{numeric}. Single latitude}
 
-\item{lon}{: \code{numeric}. Single longitude}
+\item{lon}{\code{numeric}. Single longitude}
 
-\item{data}{: \code{data.frame}. Alternative to use \code{date}, \code{lat}, \code{lon} for passing multiple coordinates}
+\item{data}{\code{data.frame}. Alternative to use \code{date}, \code{lat}, \code{lon} for passing multiple coordinates}
 
-\item{keep}{: \code{character}. Vector of variables to keep. See \code{Details}}
+\item{keep}{\code{character}. Vector of variables to keep. See \code{Details}}
 
-\item{tz}{: \code{character}. Timezone of results}
+\item{tz}{\code{character}. Timezone of results}
 }
 \value{
 \code{data.frame}
@@ -37,21 +37,21 @@ Get Sunlight times
 \details{
 Available variables are :
 
-\itemize{
-  \item{"sunrise"}{ : sunrise (top edge of the sun appears on the horizon)}
-  \item{"sunriseEnd"}{ : sunrise ends (bottom edge of the sun touches the horizon)}
-  \item{"goldenHourEnd"}{ : morning golden hour (soft light, best time for photography) ends}
-  \item{"solarNoon"}{ : solar noon (sun is in the highest position)}
-  \item{"goldenHour"}{ : evening golden hour starts}
-  \item{"sunsetStart"}{ : sunset starts (bottom edge of the sun touches the horizon)}
-  \item{"sunset"}{ : sunset (sun disappears below the horizon, evening civil twilight starts)}
-  \item{"dusk"}{ : dusk (evening nautical twilight starts)}
-  \item{"nauticalDusk"}{ : nautical dusk (evening astronomical twilight starts)}
-  \item{"night"}{ : night starts (dark enough for astronomical observations)}
-  \item{"nadir"}{ : nadir (darkest moment of the night, sun is in the lowest position)}
-  \item{"nightEnd"}{ : night ends (morning astronomical twilight starts)}
-  \item{"nauticalDawn"}{ : nautical dawn (morning nautical twilight starts)}
-  \item{"dawn"}{ : dawn (morning nautical twilight ends, morning civil twilight starts)}
+\describe{
+  \item{"sunrise"}{sunrise (top edge of the sun appears on the horizon)}
+  \item{"sunriseEnd"}{sunrise ends (bottom edge of the sun touches the horizon)}
+  \item{"goldenHourEnd"}{morning golden hour (soft light, best time for photography) ends}
+  \item{"solarNoon"}{solar noon (sun is in the highest position)}
+  \item{"goldenHour"}{evening golden hour starts}
+  \item{"sunsetStart"}{sunset starts (bottom edge of the sun touches the horizon)}
+  \item{"sunset"}{sunset (sun disappears below the horizon, evening civil twilight starts)}
+  \item{"dusk"}{dusk (evening nautical twilight starts)}
+  \item{"nauticalDusk"}{nautical dusk (evening astronomical twilight starts)}
+  \item{"night"}{night starts (dark enough for astronomical observations)}
+  \item{"nadir"}{nadir (darkest moment of the night, sun is in the lowest position)}
+  \item{"nightEnd"}{night ends (morning astronomical twilight starts)}
+  \item{"nauticalDawn"}{nautical dawn (morning nautical twilight starts)}
+  \item{"dawn"}{dawn (morning nautical twilight ends, morning civil twilight starts)}
 }
 }
 \examples{
@@ -74,6 +74,10 @@ getSunlightTimes(data = data,
       
 }
 \seealso{
-\link{getSunlightTimes}, \link{getMoonTimes}, \link{getMoonIllumination},
-\link{getMoonPosition},\link{getSunlightPosition}
+Other suncalc functions:
+\code{\link[=getMoonIllumination]{getMoonIllumination()}},
+\code{\link[=getMoonPosition]{getMoonPosition()}},
+\code{\link[=getMoonTimes]{getMoonTimes()}},
+\code{\link[=getSunlightPosition]{getSunlightPosition()}}
 }
+\concept{suncalc functions}


### PR DESCRIPTION
This also fixes a corresponding `R CMD check` NOTE.

You'll still have to bump the Version in the `DESCRIPTION` but could then do a patch release.

Thanks for actively maintaining this package on CRAN! (CC @bthieurmel : not sure who is currently in charge of this.)